### PR TITLE
Framework to introduce explainer guide and template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
-# starter-kit
+# WICG Starter kit
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/WICG/starter-kit.svg)](https://greenkeeper.io/)
-A simple starter kit for [WICG](https://wicg.io) specs.
+Welcome!  This is a simple starter kit for writing [WICG](https://wicg.io) specifications, and adding new awesome features to the web platform.  In this repo you'll find templates and guides for using them.
+
+## Process
+
+Start with an explainer. [Learn more](#TODO-slightlylate) and [get the template](https://github.com/WICG/starter-kit/blob/master/templates/explainer.md).  The explainer is critical to getting early engagement and understanding about what you'll be building.
+
+When you move into writing the spec itself, use a document framework such as [ReSpec](https://github.com/w3c/respec) or [Bikeshed](https://github.com/tabatkins/bikeshed).  This will ensure that you apply the appropriate metadata and provide details to help people locate the spec and understand the structure.
+
+<TODO: include details of good and bad specs here>
+
+
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,9 @@ Welcome!  This is a simple starter kit for writing [WICG](https://wicg.io) speci
 
 ## Process
 
-Start with an explainer. [Learn more](#TODO-slightlylate) and [get the template](https://github.com/WICG/starter-kit/blob/master/templates/explainer.md).  The explainer is critical to getting early engagement and understanding about what you'll be building.
+Start with an explainer. [Learn more](https://docs.google.com/document/d/1cJs7GkdQolqOHns9k6v1UjCUb_LqTFVjZM-kc3TbNGI/edit) and [get the template](https://github.com/WICG/starter-kit/blob/master/templates/explainer.md).  The explainer is critical to getting early engagement and understanding about what you'll be building.
 
 When you move into writing the spec itself, use a document framework such as [ReSpec](https://github.com/w3c/respec) or [Bikeshed](https://github.com/tabatkins/bikeshed).  This will ensure that you apply the appropriate metadata and provide details to help people locate the spec and understand the structure.
-
-<TODO: include details of good and bad specs here>
-
 
 
 ## Install


### PR DESCRIPTION
In https://github.com/w3ctag/design-reviews/issues/136, the TAG has been thinking about a style/structure checklist for spec authoring, mostly around explainers.  This is an initial proposal for how we could integrate that into the starter kit, which we could develop if there's agreement on it in principle.