### PR TITLE
Remove the word "simply" from instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple starter kit for [WICG](https://wicg.io) specs.
 
 ## Install
 
-Simply type the following and follow the prompts:
+Type the following and follow the prompts:
 
 ```Bash
 npm install -g wicg


### PR DESCRIPTION
Though the intention is probably to communicate that the instructions are short, using words like "simply" or "just" can have the opposite effect, making the audience feel bad for not feeling that npm installs (for example) are "simple".

https://bradfrost.com/blog/post/just/